### PR TITLE
docs: update docker image tags to 'latest' in installation guide

### DIFF
--- a/apps/docs/content/docs/2.0.0-beta/installation.mdx
+++ b/apps/docs/content/docs/2.0.0-beta/installation.mdx
@@ -30,7 +30,7 @@ Below is the complete content of our `docker-compose.yaml` that can be copied di
 ```yaml
 services:
   palmr-api:
-    image: kyantech/palmr-api:v2.0.0-beta # Make sure to use the correct version (latest) of the image
+    image: kyantech/palmr-api:latest # Make sure to use the correct version (latest) of the image
     container_name: palmr-api
     depends_on:
       postgres:
@@ -61,7 +61,7 @@ services:
       start_period: 30s
 
   palmr-app:
-    image: kyantech/palmr-app:v2.0.0-beta # Make sure to use the correct version (latest) of the image
+    image: kyantech/palmr-app:latest # Make sure to use the correct version (latest) of the image
     container_name: palmr-web
     depends_on:
       palmr-api:


### PR DESCRIPTION
This change ensures that the installation guide uses the 'latest' tag for docker images instead of the specific 'v2.0.0-beta' version, making it easier for users to always get the most recent version without manually updating the tag.