### PR TITLE
Fix healthcheck and environment variables in docker-compose.yml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     environment:
       - PORT=${API_INTERNAL_PORT:-3333} # Port for the backend service
       - DATABASE_URL=postgresql://postgres:${POSTGRESQL_PASSWORD:-postgresRootPassword}@postgres:5432/palmr_db?schema=public # Database URL with configurable password through POSTGRESQL_PASSWORD env var
-      - MINIO_ENDPOINT=minio # This can change if your MinIO is at a different address
+      - MINIO_ENDPOINT=${MINIO_ENDPOINT:-minio} # This can change if your MinIO is at a different address
       - MINIO_PORT=${MINIO_INTERNAL_API_PORT:-6421} # Default MinIO port (Change if yours is not the default)
       - MINIO_USE_SSL=false # MinIO uses SSL by default, but you can change it to true if needed
       - MINIO_ROOT_USER=${MINIO_ROOT_USER:-minio_root_user} # MinIO credentials can be configured through MINIO_ROOT_USER env vars
@@ -24,7 +24,7 @@ services:
       - "${API_EXTERNAL_PORT:-3333}:${API_INTERNAL_PORT:-3333}" # Backend port mapping 
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${API_INTERNAL_PORT:-3333}/health"]
+      test: ["CMD", "wget", "--no-verbose", "http://palmr-api:${API_INTERNAL_PORT:-3333}/health"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
First of all, this is a really great project. Thank you for appealing to my use case. Also, it has clean UI and good use of services.

However,
1. Upon running the untouched `docker-compose.yml`, I noticed that the healthcheck for `palmr-api` is always failing. This is due to missing `curl` within the image so replacing it with `wget` made it work since the latest image has `wget` pre-installed.

2. Trying to fix the endpoint for MinIO to successfully upload files while under a proxy host, I noticed that `MINIO_ENDPOINT` variable was not working as intended. Adding a optional default to the `MINIO_ENDPOINT` variable in `docker-compose.yml` should fix it for those using a different `MINIO_ENDPOINT`.