### PR TITLE
Remove hardcoded environment variables from supervisord.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,7 @@ autostart=true
 autorestart=true
 stderr_logfile=/var/log/supervisor/server.err.log
 stdout_logfile=/var/log/supervisor/server.out.log
-environment=PORT=3333,HOME="/home/palmr",ENABLE_S3="false",ENCRYPTION_KEY="default-key-change-in-production"
+environment=PORT=3333,HOME="/home/palmr"
 priority=100
 
 [program:web]


### PR DESCRIPTION
This fixes #50 (tested and working with S3), but my understanding is a pretty major security issue too since the ENCRYPTION_KEY variable is hardcoded in this line. 

With these set, supervisord will _always_ use the variables set in this configuration instead of whatever is provided via container environment variables. I believe this means every palmr deployment out there right now is hardcoded to use this encryption key. 

