### PR TITLE
fix(docker): resolve bind-mount overwrite by using symlinks for persistent data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,8 +86,7 @@ RUN mkdir -p /app/server /app/web /home/palmr/.npm /home/palmr/.cache \
   /data/server/uploads /data/server/temp-chunks /data/server/uploads/logo \
   /app/server/prisma && \
   ln -s /data/server/uploads /app/server/uploads && \
-  ln -s /data/server/temp-chunks /app/server/temp-chunks && \
-  ln -s /data/server/uploads/logo /app/server/uploads/logo 
+  ln -s /data/server/temp-chunks /app/server/temp-chunks
 
 RUN chown -R palmr:nodejs /app /home/palmr /data
 

--- a/apps/docs/content/docs/3.0-beta/api.mdx
+++ b/apps/docs/content/docs/3.0-beta/api.mdx
@@ -34,7 +34,7 @@ docker run -d \
   -e ENCRYPTION_KEY=change-this-key-in-production-min-32-chars \
   -p 5487:5487 \
   -p 3333:3333 \
-  -v palmr_data:/app/server \
+  -v palmr_data:/data \
   --restart unless-stopped \
   kyantech/palmr:latest
 ```

--- a/apps/docs/content/docs/3.0-beta/quick-start.mdx
+++ b/apps/docs/content/docs/3.0-beta/quick-start.mdx
@@ -42,7 +42,7 @@ services:
       - "5487:5487" # Web port
       - "3333:3333" # API port (OPTIONAL EXPOSED - ONLY IF YOU WANT TO ACCESS THE API DIRECTLY, IF YOU DONT WANT TO EXPOSE THE API, JUST REMOVE THIS LINE )
     volumes:
-      - palmr_data:/app/server # Volume for the application data
+      - palmr_data:/data # Volume for the application data
     restart: unless-stopped # Restart the container unless it is stopped
 
 volumes:
@@ -84,6 +84,11 @@ To ensure your data sticks around even if the container restarts, we use a persi
 | ------------ | ------------------------------------- |
 | `palmr_data` | Stores all the data of Palmr. service |
 
+Alternatively, you can use a bind-mount to map a Directory from your Host-System to the Palmr container.
+```
+    volumes:
+      - /path/on/your/host/system:/data # Volume for the application data
+```
 ---
 
 ## Launching Palmr.
@@ -138,7 +143,7 @@ docker run -d \
   -e ENCRYPTION_KEY=change-this-key-in-production-min-32-chars \
   -p 5487:5487 \
   -p 3333:3333 \
-  -v palmr_data:/app/server \
+  -v palmr_data:/data \
   --restart unless-stopped \
   kyantech/palmr:latest
 ```

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -4,7 +4,7 @@ generator client {
 
 datasource db {
   provider = "sqlite"
-  url      = "file:./palmr.db"
+  url      = "file:/data/server/prisma/palmr.db"
 }
 
 model User {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - "5487:5487" # Web port
       - "3333:3333" # API port (OPTIONAL EXPOSED - ONLY IF YOU WANT TO ACCESS THE API DIRECTLY)
     volumes:
-      - palmr_data:/app/server # Volume for the application data
+      - palmr_data:/data # Volume for the application data
     restart: unless-stopped # Restart the container unless it is stopped
 
 volumes:


### PR DESCRIPTION
A potential workaround/fix for making bind-mounts a viable option.

This fix allows persistent storage to work with both Docker volumes and bind-mounts, preventing application files from being overwritten.

- Add symlinks for uploads, temp-chunks, and logo directories - maybe temp-chunks isn't needed. I don't know yet.
  - ln -s /data/server/uploads /app/server/uploads
  - ln -s /data/server/temp-chunks /app/server/temp-chunks
- Update Prisma schema to use /data/server/prisma/palmr.db as the default SQLite database path

Tested successfully with both, docker volumes and bind-mounts.


Results:
### /app/server
![3426](https://github.com/user-attachments/assets/92dd87da-7a67-459f-920a-cc5fd582bbda)
### /data/server
![3427](https://github.com/user-attachments/assets/b01021a3-5b3f-418f-a8cc-6438c79a4a2e)

