### PR TITLE
fix: storage calculation when running within docker

### DIFF
--- a/apps/server/src/modules/storage/service.ts
+++ b/apps/server/src/modules/storage/service.ts
@@ -9,7 +9,7 @@ const prisma = new PrismaClient();
 
 export class StorageService {
   private configService = new ConfigService();
-  private isDockerCached = false;
+  private isDockerCached = undefined;
 
   private _hasDockerEnv() {
     try {


### PR DESCRIPTION
This fixes #64 

I've added a check if the application runs within docker, swaping the storage calculation target from `.` to `/app/server/uploads` if thats the case.