### PR TITLE
feat: add reverse proxy support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,6 +132,7 @@ set -e
 
 echo "Starting Palmr Application..."
 echo "Storage Mode: \${ENABLE_S3:-false}"
+echo "Secure Site: \${SECURE_SITE:-false}"
 echo "Database: SQLite"
 
 # Set global environment variables

--- a/apps/docs/content/docs/3.0-beta/meta.json
+++ b/apps/docs/content/docs/3.0-beta/meta.json
@@ -15,6 +15,7 @@
     "configuring-smtp",
     "available-languages",
     "uid-gid-configuration",
+    "reverse-proxy-configuration",
     "password-reset-without-smtp",
     "oidc-authentication",
     "---Developers---",

--- a/apps/docs/content/docs/3.0-beta/quick-start.mdx
+++ b/apps/docs/content/docs/3.0-beta/quick-start.mdx
@@ -56,6 +56,7 @@ services:
     environment:
       - ENABLE_S3=false
       - ENCRYPTION_KEY=change-this-key-in-production-min-32-chars # CHANGE THIS KEY FOR SECURITY
+      # - SECURE_SITE=false # Set to true if you are using a reverse proxy
     ports:
       - "5487:5487" # Web interface
       - "3333:3333" # API port (OPTIONAL EXPOSED - ONLY IF YOU WANT TO ACCESS THE API DIRECTLY)
@@ -91,6 +92,7 @@ services:
     environment:
       - ENABLE_S3=false
       - ENCRYPTION_KEY=change-this-key-in-production-min-32-chars # CHANGE THIS KEY FOR SECURITY
+      # - SECURE_SITE=false # Set to true if you are using a reverse proxy
       # Optional: Set custom UID/GID for file permissions
       # - PALMR_UID=1000
       # - PALMR_GID=1000
@@ -121,8 +123,11 @@ Configure Palmr. behavior through environment variables:
 | ---------------- | ------- | ------------------------------------------------------- |
 | `ENABLE_S3`      | `false` | Enable S3-compatible storage                            |
 | `ENCRYPTION_KEY` | -       | **Required**: Minimum 32 characters for file encryption |
+| `SECURE_SITE`    | `false` | Enable secure cookies for HTTPS/reverse proxy setups    |
 
 > **⚠️ Security Warning**: Always change the `ENCRYPTION_KEY` in production. This key encrypts your files - losing it makes files permanently inaccessible.
+
+> **🔗 Reverse Proxy**: If deploying behind a reverse proxy (Traefik, Nginx, etc.), set `SECURE_SITE=true` and review our [Reverse Proxy Configuration](/docs/3.0-beta/reverse-proxy-configuration) guide for proper setup.
 
 ### Generate Secure Encryption Keys
 

--- a/apps/docs/content/docs/3.0-beta/reverse-proxy-configuration.mdx
+++ b/apps/docs/content/docs/3.0-beta/reverse-proxy-configuration.mdx
@@ -42,46 +42,6 @@ Keep `SECURE_SITE=false` (default) for:
 
 ## HTTP Reverse Proxy Setup
 
-For reverse proxies **without HTTPS/SSL** (like internal networks), use `SECURE_SITE=false` but ensure proper proxy configuration.
-
-### Nginx HTTP Configuration
-
-**Nginx Config (`/etc/nginx/sites-available/palmr`):**
-
-```nginx
-server {
-    listen 80;
-    server_name palmr.yourdomain.com;
-
-    location / {
-        proxy_pass http://localhost:5487;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $host;
-
-        # Important for cookies
-        proxy_set_header Cookie $http_cookie;
-        proxy_pass_header Set-Cookie;
-    }
-
-    # API endpoints
-    location /api {
-        proxy_pass http://localhost:3333;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $host;
-
-        # Important for cookies
-        proxy_set_header Cookie $http_cookie;
-        proxy_pass_header Set-Cookie;
-    }
-}
-```
-
 **Docker Compose for HTTP Nginx:**
 
 ```yaml

--- a/apps/docs/content/docs/3.0-beta/reverse-proxy-configuration.mdx
+++ b/apps/docs/content/docs/3.0-beta/reverse-proxy-configuration.mdx
@@ -1,0 +1,241 @@
+---
+title: Reverse Proxy Configuration
+icon: "Shield"
+---
+
+When deploying **Palmr.** behind a reverse proxy (like Traefik, Nginx, or Cloudflare), you need to configure secure cookie settings to ensure proper authentication. This guide covers the `SECURE_SITE` environment variable and related proxy configurations.
+
+## Overview
+
+Reverse proxies terminate SSL/TLS connections and forward requests to Palmr., which can cause authentication issues if cookies aren't configured properly for HTTPS environments. The `SECURE_SITE` environment variable controls cookie security settings to handle these scenarios.
+
+## The SECURE_SITE Environment Variable
+
+The `SECURE_SITE` variable configures how Palmr. handles authentication cookies based on your deployment environment:
+
+### Configuration Options
+
+| Value   | Cookie Settings                       | Use Case                            |
+| ------- | ------------------------------------- | ----------------------------------- |
+| `true`  | `secure: true`, `sameSite: "lax"`     | HTTPS/Production with reverse proxy |
+| `false` | `secure: false`, `sameSite: "strict"` | HTTP/Development (default)          |
+
+### When to Use SECURE_SITE=true
+
+Set `SECURE_SITE=true` in the following scenarios:
+
+- ✅ **Reverse Proxy with HTTPS**: Traefik, Nginx, HAProxy with SSL termination
+- ✅ **Cloud Providers**: Cloudflare, AWS ALB, Azure Application Gateway
+- ✅ **CDN with HTTPS**: Any CDN that terminates SSL
+- ✅ **Production Deployments**: When users access via HTTPS
+
+### When to Use SECURE_SITE=false
+
+Keep `SECURE_SITE=false` (default) for:
+
+- ✅ **Local Development**: Running on `http://localhost`
+- ✅ **Direct HTTP Access**: No reverse proxy involved
+- ✅ **Testing Environments**: When using HTTP
+- ✅ **HTTP Reverse Proxy**: Nginx, Apache, etc. without SSL termination
+
+---
+
+## HTTP Reverse Proxy Setup
+
+For reverse proxies **without HTTPS/SSL** (like internal networks), use `SECURE_SITE=false` but ensure proper proxy configuration.
+
+### Nginx HTTP Configuration
+
+**Nginx Config (`/etc/nginx/sites-available/palmr`):**
+
+```nginx
+server {
+    listen 80;
+    server_name palmr.yourdomain.com;
+
+    location / {
+        proxy_pass http://localhost:5487;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+
+        # Important for cookies
+        proxy_set_header Cookie $http_cookie;
+        proxy_pass_header Set-Cookie;
+    }
+
+    # API endpoints
+    location /api {
+        proxy_pass http://localhost:3333;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+
+        # Important for cookies
+        proxy_set_header Cookie $http_cookie;
+        proxy_pass_header Set-Cookie;
+    }
+}
+```
+
+**Docker Compose for HTTP Nginx:**
+
+```yaml
+services:
+  palmr:
+    image: kyantech/palmr:latest
+    container_name: palmr
+    environment:
+      - ENABLE_S3=false
+      - ENCRYPTION_KEY=your-secure-key-here
+      - SECURE_SITE=false # HTTP = false
+    ports:
+      - "127.0.0.1:5487:5487" # Bind to localhost only
+      - "127.0.0.1:3333:3333"
+    volumes:
+      - palmr_data:/app/server
+    restart: unless-stopped
+
+volumes:
+  palmr_data:
+```
+
+> **⚠️ HTTP Security**: Remember that HTTP transmits data in plain text. Consider using HTTPS in production environments.
+
+---
+
+## Troubleshooting Authentication Issues
+
+### Common Symptoms
+
+If you experience authentication issues behind a reverse proxy:
+
+- ❌ Login appears successful but redirects to login page
+- ❌ "No Authorization was found in request.cookies" errors
+- ❌ API requests return 401 Unauthorized
+- ❌ User registration fails silently
+
+### Diagnostic Steps
+
+1. **Check Browser Developer Tools**:
+
+   - Look for cookies in Application/Storage tab
+   - Verify cookie has `Secure` flag when using HTTPS
+   - Check if `SameSite` attribute is appropriate
+
+2. **Verify Environment Variables**:
+
+   ```bash
+   docker exec -it palmr env | grep SECURE_SITE
+   ```
+
+3. **Test Cookie Settings**:
+   - With `SECURE_SITE=false`: Should work on HTTP
+   - With `SECURE_SITE=true`: Should work on HTTPS
+
+### Common Fixes
+
+**Problem**: Authentication fails with reverse proxy
+
+**Solution**: Set `SECURE_SITE=true` and ensure proper headers:
+
+```yaml
+environment:
+  - SECURE_SITE=true
+```
+
+**Problem**: Mixed content errors
+
+**Solution**: Ensure proxy passes correct headers:
+
+```yaml
+# Traefik
+- "traefik.http.middlewares.palmr-headers.headers.customrequestheaders.X-Forwarded-Proto=https"
+
+# Nginx
+proxy_set_header X-Forwarded-Proto $scheme;
+```
+
+**Problem**: Authentication fails with HTTP reverse proxy
+
+**Solution**: Use `SECURE_SITE=false` and ensure proper cookie headers:
+
+```yaml
+environment:
+  - SECURE_SITE=false # For HTTP proxy
+```
+
+```nginx
+# Nginx - Add these headers for cookie handling
+proxy_set_header Cookie $http_cookie;
+proxy_pass_header Set-Cookie;
+```
+
+---
+
+## Security Considerations
+
+> **⚠️ Important**: Always use HTTPS in production environments. The `SECURE_SITE=true` setting ensures cookies are only sent over encrypted connections.
+
+---
+
+## Advanced Configuration
+
+### Multiple Domains
+
+If serving Palmr. on multiple domains, ensure consistent cookie settings:
+
+```yaml
+environment:
+  - SECURE_SITE=true # Use for all HTTPS domains
+```
+
+### Development vs Production
+
+Use environment-specific configurations:
+
+**Development (HTTP):**
+
+```yaml
+environment:
+  - SECURE_SITE=false
+```
+
+**Production (HTTPS):**
+
+```yaml
+environment:
+  - SECURE_SITE=true
+```
+
+### Health Checks
+
+Add health checks to ensure proper proxy configuration:
+
+```yaml
+services:
+  palmr:
+    # ... other config
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5487/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+```
+
+---
+
+## Need Help?
+
+If you're still experiencing issues after following this guide:
+
+1. **Check the Logs**: `docker logs palmr`
+2. **Verify Headers**: Use browser dev tools or `curl -I`
+3. **Test Direct Access**: Try accessing Palmr. directly (bypassing proxy)
+4. **Open an Issue**: [Report bugs on GitHub](https://github.com/kyantech/Palmr/issues)
+
+> **💡 Pro Tip**: When reporting issues, include your reverse proxy configuration and any relevant error messages from both Palmr. and your proxy logs.

--- a/apps/docs/content/docs/3.0-beta/reverse-proxy-configuration.mdx
+++ b/apps/docs/content/docs/3.0-beta/reverse-proxy-configuration.mdx
@@ -120,6 +120,19 @@ proxy_set_header Cookie $http_cookie;
 proxy_pass_header Set-Cookie;
 ```
 
+**Problem**: SQLite "readonly database" error with bind mounts
+
+**Solution**: Configure proper UID/GID permissions:
+
+```yaml
+environment:
+  - PALMR_UID=1000 # Your host UID (check with: id)
+  - PALMR_GID=1000 # Your host GID
+  - ENCRYPTION_KEY=your-key-here
+```
+
+> **💡 Note**: Check your host UID/GID with `id` command and use those values. See [UID/GID Configuration](/docs/3.0-beta/uid-gid-configuration) for detailed setup.
+
 ---
 
 ## Security Considerations

--- a/apps/docs/content/docs/3.0-beta/reverse-proxy-configuration.mdx
+++ b/apps/docs/content/docs/3.0-beta/reverse-proxy-configuration.mdx
@@ -85,23 +85,8 @@ server {
 **Docker Compose for HTTP Nginx:**
 
 ```yaml
-services:
-  palmr:
-    image: kyantech/palmr:latest
-    container_name: palmr
-    environment:
-      - ENABLE_S3=false
-      - ENCRYPTION_KEY=your-secure-key-here
-      - SECURE_SITE=false # HTTP = false
-    ports:
-      - "127.0.0.1:5487:5487" # Bind to localhost only
-      - "127.0.0.1:3333:3333"
-    volumes:
-      - palmr_data:/app/server
-    restart: unless-stopped
-
-volumes:
-  palmr_data:
+environment:
+  - SECURE_SITE=false # HTTP = false
 ```
 
 > **⚠️ HTTP Security**: Remember that HTTP transmits data in plain text. Consider using HTTPS in production environments.

--- a/apps/server/src/env.ts
+++ b/apps/server/src/env.ts
@@ -11,6 +11,7 @@ const envSchema = z.object({
   S3_REGION: z.string().optional(),
   S3_BUCKET_NAME: z.string().optional(),
   S3_FORCE_PATH_STYLE: z.union([z.literal("true"), z.literal("false")]).default("false"),
+  SECURE_SITE: z.union([z.literal("true"), z.literal("false")]).default("false"),
   DATABASE_URL: z.string().optional().default("file:/app/server/prisma/palmr.db"),
 });
 

--- a/apps/server/src/modules/auth/controller.ts
+++ b/apps/server/src/modules/auth/controller.ts
@@ -1,5 +1,6 @@
 import { LoginSchema, RequestPasswordResetSchema, createResetPasswordSchema } from "./dto";
 import { AuthService } from "./service";
+import { env } from "env";
 import { FastifyReply, FastifyRequest } from "fastify";
 
 export class AuthController {
@@ -17,8 +18,8 @@ export class AuthController {
       reply.setCookie("token", token, {
         httpOnly: true,
         path: "/",
-        secure: false,
-        sameSite: "strict",
+        secure: env.SECURE_SITE === "true" ? true : false,
+        sameSite: env.SECURE_SITE === "true" ? "lax" : "strict",
       });
 
       return reply.send({ user });

--- a/apps/server/src/modules/email/service.ts
+++ b/apps/server/src/modules/email/service.ts
@@ -1,4 +1,5 @@
 import { ConfigService } from "../config/service";
+import { env } from "env";
 import nodemailer from "nodemailer";
 
 export class EmailService {
@@ -13,7 +14,7 @@ export class EmailService {
     return nodemailer.createTransport({
       host: await this.configService.getValue("smtpHost"),
       port: Number(await this.configService.getValue("smtpPort")),
-      secure: false,
+      secure: env.SECURE_SITE === "true" ? true : false,
       auth: {
         user: await this.configService.getValue("smtpUser"),
         pass: await this.configService.getValue("smtpPass"),

--- a/apps/web/src/app/auth/callback/page.tsx
+++ b/apps/web/src/app/auth/callback/page.tsx
@@ -14,8 +14,8 @@ export default function AuthCallbackPage() {
     if (token) {
       Cookies.set("token", token, {
         path: "/",
-        secure: false,
-        sameSite: "strict",
+        secure: window.location.protocol === "https:",
+        sameSite: window.location.protocol === "https:" ? "lax" : "strict",
         httpOnly: false,
       });
 

--- a/apps/web/src/app/login/hooks/use-login.ts
+++ b/apps/web/src/app/login/hooks/use-login.ts
@@ -49,6 +49,17 @@ export function useLogin() {
   useEffect(() => {
     const checkAuth = async () => {
       try {
+        const appInfoResponse = await fetch("/api/app/info");
+        const appInfo = await appInfoResponse.json();
+
+        if (appInfo.firstUserAccess) {
+          setUser(null);
+          setIsAdmin(false);
+          setIsAuthenticated(false);
+          setIsInitialized(true);
+          return;
+        }
+
         const userResponse = await getCurrentUser();
         if (!userResponse?.data?.user) {
           throw new Error("No user data");

--- a/apps/web/src/components/general/language-switcher.tsx
+++ b/apps/web/src/components/general/language-switcher.tsx
@@ -49,7 +49,7 @@ export function LanguageSwitcher() {
       maxAge: COOKIE_MAX_AGE,
       path: "/",
       sameSite: "lax",
-      secure: false,
+      secure: window.location.protocol === "https:",
     });
 
     router.refresh();


### PR DESCRIPTION
**Description**

This PR adds reverse proxy support to Palmr., allowing the application to operate seamlessly behind reverse proxies such as NGINX, Traefik, or Caddy. The main changes include:

- Configuration updates to recognize and handle X-Forwarded-For and X-Forwarded-Proto headers, ensuring correct identification of client IPs and protocols.
- Adjustments to environment variables and documentation to simplify deployment behind a reverse proxy.
- Security and compatibility improvements for a wider range of infrastructure scenarios.

**Motivation**

Reverse proxy support is crucial for production environments, where proxies are commonly used for SSL termination, load balancing, and enhanced security or performance.

**How to test**

- Deploy Palmr. behind a reverse proxy (e.g., NGINX) and verify that links, authentication, and client IP detection work as expected.
- Test both HTTP and HTTPS scenarios to ensure protocol detection is accurate.
