### PR TITLE
Update service.ts

### DIFF
--- a/apps/server/src/modules/email/service.ts
+++ b/apps/server/src/modules/email/service.ts
@@ -14,7 +14,7 @@ export class EmailService {
     return nodemailer.createTransport({
       host: await this.configService.getValue("smtpHost"),
       port: Number(await this.configService.getValue("smtpPort")),
-      secure: env.SECURE_SITE === "true" ? true : false,
+      secure: false,
       auth: {
         user: await this.configService.getValue("smtpUser"),
         pass: await this.configService.getValue("smtpPass"),


### PR DESCRIPTION
Fix nodemailer secure flag for STARTTLS. The best practice would be to also use requireTLS: true but I did not explicitly include this in case some users  were using internal home lab mail servers that do not support STARTTLS. In the future, it would be beneficial to have this accessed via an additional env or set within the SMTP Configuration page. 