### PR TITLE
feat: Add S3_REJECT_UNAUTHORIZED environment variable 

### DIFF
--- a/apps/docs/content/docs/3.1-beta/quick-start.mdx
+++ b/apps/docs/content/docs/3.1-beta/quick-start.mdx
@@ -140,6 +140,7 @@ Customize Palmr's behavior with these environment variables:
 | Variable                        | Default | Description                                                                                  |
 | ------------------------------- | ------- | -------------------------------------------------------------------------------------------- |
 | `ENABLE_S3`                     | `false` | Enable S3-compatible storage backends                                                        |
+| `S3_REJECT_UNAUTHORIZED`        | `true`  | Enable strict SSL certificate validation for S3 (set to `false` for self-signed certificates) |
 | `ENCRYPTION_KEY`                | -       | **Required when encryption is enabled**: 32+ character key for file encryption               |
 | `DISABLE_FILESYSTEM_ENCRYPTION` | `true`  | Disable file encryption for better performance (set to `false` to enable encryption)         |
 | `SECURE_SITE`                   | `false` | Enable secure cookies for HTTPS/reverse proxy deployments                                    |

--- a/apps/docs/content/docs/3.1-beta/s3-providers.mdx
+++ b/apps/docs/content/docs/3.1-beta/s3-providers.mdx
@@ -21,16 +21,17 @@ Consider using S3-compatible storage when you need:
 
 To enable S3-compatible storage, set `ENABLE_S3=true` and configure the following environment variables:
 
-| Variable              | Description                   | Required | Default           |
-| --------------------- | ----------------------------- | -------- | ----------------- |
-| `S3_ENDPOINT`         | S3 provider endpoint URL      | Yes      | -                 |
-| `S3_PORT`             | Connection port               | No       | Based on protocol |
-| `S3_USE_SSL`          | Enable SSL/TLS encryption     | Yes      | `true`            |
-| `S3_ACCESS_KEY`       | Access key for authentication | Yes      | -                 |
-| `S3_SECRET_KEY`       | Secret key for authentication | Yes      | -                 |
-| `S3_REGION`           | Storage region                | Yes      | -                 |
-| `S3_BUCKET_NAME`      | Bucket/container name         | Yes      | -                 |
-| `S3_FORCE_PATH_STYLE` | Use path-style URLs           | No       | `false`           |
+| Variable                | Description                           | Required | Default           |
+| ----------------------- | ------------------------------------- | -------- | ----------------- |
+| `S3_ENDPOINT`           | S3 provider endpoint URL              | Yes      | -                 |
+| `S3_PORT`               | Connection port                       | No       | Based on protocol |
+| `S3_USE_SSL`            | Enable SSL/TLS encryption             | Yes      | `true`            |
+| `S3_ACCESS_KEY`         | Access key for authentication         | Yes      | -                 |
+| `S3_SECRET_KEY`         | Secret key for authentication         | Yes      | -                 |
+| `S3_REGION`             | Storage region                        | Yes      | -                 |
+| `S3_BUCKET_NAME`        | Bucket/container name                 | Yes      | -                 |
+| `S3_FORCE_PATH_STYLE`   | Use path-style URLs                   | No       | `false`           |
+| `S3_REJECT_UNAUTHORIZED`| Enable strict SSL certificate validation | No    | `true`            |
 
 ## Provider configurations
 
@@ -80,6 +81,21 @@ S3_FORCE_PATH_STYLE=true
 - Use `S3_FORCE_PATH_STYLE=true` for MinIO
 - Default MinIO port is 9000
 - SSL can be disabled for local development
+
+**For MinIO with self-signed SSL certificates:**
+
+```bash
+ENABLE_S3=true
+S3_ENDPOINT=your-minio-domain.com
+S3_PORT=9000
+S3_USE_SSL=true
+S3_ACCESS_KEY=your-minio-access-key
+S3_SECRET_KEY=your-minio-secret-key
+S3_REGION=us-east-1
+S3_BUCKET_NAME=your-bucket-name
+S3_FORCE_PATH_STYLE=true
+S3_REJECT_UNAUTHORIZED=false  # Allows self-signed certificates
+```
 
 ### Google Cloud Storage
 
@@ -211,6 +227,19 @@ S3_FORCE_PATH_STYLE=false
 - Verify endpoint URL and port settings
 - Check firewall and network connectivity
 - Ensure SSL/TLS settings match provider requirements
+
+**SSL certificate errors (self-signed certificates):**
+
+If you encounter errors like `unable to verify the first certificate` or `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, you're likely using self-signed SSL certificates. This is common with self-hosted MinIO or other S3-compatible services.
+
+**Solution:**
+Set `S3_REJECT_UNAUTHORIZED=false` in your environment variables to allow self-signed certificates:
+
+```bash
+S3_REJECT_UNAUTHORIZED=false
+```
+
+**Note:** SSL certificate validation is enabled by default (`true`) for security. Set it to `false` only when using self-hosted S3 services with self-signed certificates.
 
 **Authentication failures:**
 

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -14,3 +14,4 @@ DATABASE_URL="file:./palmr.db"
 # S3_REGION=
 # S3_BUCKET_NAME=
 # S3_FORCE_PATH_STYLE=
+# S3_REJECT_UNAUTHORIZED=true # Set to false to disable strict SSL certificate validation for self-signed certificates (optional, defaults to true)

--- a/apps/server/src/config/storage.config.ts
+++ b/apps/server/src/config/storage.config.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import { S3Client } from "@aws-sdk/client-s3";
 
 import { env } from "../env";
@@ -13,6 +14,14 @@ export const storageConfig: StorageConfig = {
   bucketName: env.S3_BUCKET_NAME || "",
   forcePathStyle: env.S3_FORCE_PATH_STYLE === "true",
 };
+
+if (storageConfig.useSSL && env.S3_REJECT_UNAUTHORIZED === "false") {
+  const originalRejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+  if (!originalRejectUnauthorized) {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+    (global as any).PALMR_ORIGINAL_TLS_SETTING = originalRejectUnauthorized;
+  }
+}
 
 export const s3Client =
   env.ENABLE_S3 === "true"

--- a/apps/server/src/env.ts
+++ b/apps/server/src/env.ts
@@ -12,6 +12,7 @@ const envSchema = z.object({
   S3_REGION: z.string().optional(),
   S3_BUCKET_NAME: z.string().optional(),
   S3_FORCE_PATH_STYLE: z.union([z.literal("true"), z.literal("false")]).default("false"),
+  S3_REJECT_UNAUTHORIZED: z.union([z.literal("true"), z.literal("false")]).default("true"),
   SECURE_SITE: z.union([z.literal("true"), z.literal("false")]).default("false"),
   DATABASE_URL: z.string().optional().default("file:/app/server/prisma/palmr.db"),
 });

--- a/docker-compose-bind-mount-example.yaml
+++ b/docker-compose-bind-mount-example.yaml
@@ -5,6 +5,7 @@ services:
     environment:
       # Optional: Uncomment and configure as needed (if you don`t use, you can remove)
       # - ENABLE_S3=true # Set to true to enable S3-compatible storage (OPTIONAL - default is false)
+      # - S3_REJECT_UNAUTHORIZED=false # Set to false to allow self-signed certificates (OPTIONAL - default is true)
       # - DISABLE_FILESYSTEM_ENCRYPTION=false # Set to false to enable file encryption (ENCRYPTION_KEY becomes required) | (OPTIONAL - default is true)
       # - ENCRYPTION_KEY=change-this-key-in-production-min-32-chars # CHANGE THIS KEY FOR SECURITY (REQUIRED if DISABLE_FILESYSTEM_ENCRYPTION is false)
       # - PALMR_UID=1000 # UID for the container processes (OPTIONAL - default is 1000) | See our UID/GID Documentation for more information

--- a/docker-compose-minio.yaml
+++ b/docker-compose-minio.yaml
@@ -12,6 +12,7 @@ services:
       - S3_REGION=${S3_REGION:-us-east-1} # S3 region (us-east-1 is the default region) but it depends on your s3 server region
       - S3_BUCKET_NAME=${S3_BUCKET_NAME:-palmr-files} # Bucket name for the S3 storage (here we are using palmr-files as the bucket name to understand that this is the bucket for palmr)
       - S3_FORCE_PATH_STYLE=true # For MinIO compatibility we have to set this to true
+      # - S3_REJECT_UNAUTHORIZED=false # Set to false to allow self-signed certificates (default: true)
       # - PALMR_UID=1000 # UID for the container processes (OPTIONAL - default is 1000) | See our UID/GID Documentation for more information
       # - PALMR_GID=1000 # GID for the container processes (OPTIONAL - default is 1000) | See our UID/GID Documentation for more information
       # - DEFAULT_LANGUAGE=en-US # Default language for the application (optional, defaults to en-US) | See the docs for see all supported languages

--- a/docker-compose-s3.yaml
+++ b/docker-compose-s3.yaml
@@ -12,6 +12,7 @@ services:
       - S3_REGION=${S3_REGION:-us-east-1} # S3 region (us-east-1 is the default region) but it depends on your s3 server region
       - S3_BUCKET_NAME=${S3_BUCKET_NAME:-palmr-files} # Bucket name for the S3 storage (here we are using palmr-files as the bucket name to understand that this is the bucket for palmr)
       - S3_FORCE_PATH_STYLE=false # For S3 compatibility we have to set this to false
+      # - S3_REJECT_UNAUTHORIZED=false # Set to false to allow self-signed certificates (default: true)
       # - PALMR_UID=1000 # UID for the container processes (OPTIONAL - default is 1000) | See our UID/GID Documentation for more information
       # - PALMR_GID=1000 # GID for the container processes (OPTIONAL - default is 1000) | See our UID/GID Documentation for more information
       # - DEFAULT_LANGUAGE=en-US # Default language for the application (optional, defaults to en-US) | See the docs for see all supported languages

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
     environment:
       # Optional: Uncomment and configure as needed (if you don`t use, you can remove)
       # - ENABLE_S3=false # Set to true to enable S3-compatible storage (OPTIONAL - default is false)
+      # - S3_REJECT_UNAUTHORIZED=false # Set to false to allow self-signed certificates (OPTIONAL - default is true)
       # - DISABLE_FILESYSTEM_ENCRYPTION=true # Set to false to enable file encryption (ENCRYPTION_KEY becomes required) | (OPTIONAL - default is true)
       # - ENCRYPTION_KEY=change-this-key-in-production-min-32-chars # CHANGE THIS KEY FOR SECURITY (REQUIRED if DISABLE_FILESYSTEM_ENCRYPTION is false)
       # - PALMR_UID=1000 # UID for the container processes (OPTIONAL - default is 1000) | See our UID/GID Documentation for more information


### PR DESCRIPTION
- Introduced the S3_REJECT_UNAUTHORIZED variable across multiple configuration files to allow users to disable strict SSL certificate validation for self-signed certificates.
- Updated documentation to reflect the new variable and its usage in various contexts, including examples for MinIO and S3-compatible services.
- Enhanced server configuration to handle the new variable appropriately, ensuring compatibility with self-hosted S3 solutions.
