### PR TITLE
feat: add PRESIGNED_URL_EXPIRATION configuration option

### DIFF
--- a/apps/docs/content/docs/3.1-beta/quick-start.mdx
+++ b/apps/docs/content/docs/3.1-beta/quick-start.mdx
@@ -69,6 +69,7 @@ Choose your storage method based on your needs:
           # - PALMR_GID=1000 # GID for the container processes (default is 1000)
           # - SECURE_SITE=false # Set to true if you are using a reverse proxy
           # - DEFAULT_LANGUAGE=en-US # Default language for the application (optional, defaults to en-US)
+          # - PRESIGNED_URL_EXPIRATION=3600 # Duration in seconds for presigned URL expiration (optional, defaults to 3600 seconds / 1 hour)
         volumes:
           - palmr_data:/app/server
 
@@ -116,6 +117,7 @@ Choose your storage method based on your needs:
           # - PALMR_GID=1000 # GID for the container processes (default is 1000)
           # - SECURE_SITE=false # Set to true if you are using a reverse proxy
           # - DEFAULT_LANGUAGE=en-US # Default language for the application (optional, defaults to en-US)
+          # - PRESIGNED_URL_EXPIRATION=3600 # Duration in seconds for presigned URL expiration (optional, defaults to 3600 seconds / 1 hour)
         volumes:
           - ./data:/app/server
     ```
@@ -248,6 +250,40 @@ Prefer Docker commands over Compose? Here are the equivalent commands:
 
   </Tab>
 </Tabs>
+
+---
+
+## Common Configuration Options
+
+### Presigned URL Expiration
+
+Palmr. uses temporary URLs (presigned URLs) for secure file access. These URLs expire after a configurable time period to enhance security.
+
+**Default:** 1 hour (3600 seconds)
+
+You can customize this for all storage types (filesystem or S3) by adding:
+
+```yaml
+environment:
+  - PRESIGNED_URL_EXPIRATION=7200  # 2 hours
+```
+
+**When to adjust:**
+- **Shorter time (1800 = 30 min):** Higher security, but users may need to refresh download links
+- **Longer time (7200-21600 = 2-6 hours):** Better for large file transfers, but URLs stay valid longer
+- **Default (3600 = 1 hour):** Good balance for most use cases
+
+### File Encryption
+
+For filesystem storage, you can enable file encryption:
+
+```yaml
+environment:
+  - DISABLE_FILESYSTEM_ENCRYPTION=false
+  - ENCRYPTION_KEY=your-secure-32-character-key-here
+```
+
+**Note:** S3 storage handles encryption through your S3 provider's encryption features.
 
 ---
 

--- a/apps/docs/content/docs/3.1-beta/s3-providers.mdx
+++ b/apps/docs/content/docs/3.1-beta/s3-providers.mdx
@@ -7,6 +7,8 @@ This guide provides comprehensive configuration instructions for integrating Pal
 
 > **Overview:** Palmr. supports any S3-compatible storage provider, giving you flexibility to choose the solution that best fits your needs and budget.
 
+> **Note:** Some configuration options (like presigned URL expiration) apply to **all storage types**, including filesystem storage. These are marked accordingly in the documentation.
+
 ## When to use S3-compatible storage
 
 Consider using S3-compatible storage when you need:
@@ -19,19 +21,27 @@ Consider using S3-compatible storage when you need:
 
 ## Environment variables
 
+### General configuration (applies to all storage types)
+
+| Variable                   | Description                                      | Required | Default         |
+| -------------------------- | ------------------------------------------------ | -------- | --------------- |
+| `PRESIGNED_URL_EXPIRATION` | Duration in seconds for presigned URL expiration | No       | `3600` (1 hour) |
+
+### S3-specific configuration
+
 To enable S3-compatible storage, set `ENABLE_S3=true` and configure the following environment variables:
 
-| Variable                | Description                           | Required | Default           |
-| ----------------------- | ------------------------------------- | -------- | ----------------- |
-| `S3_ENDPOINT`           | S3 provider endpoint URL              | Yes      | -                 |
-| `S3_PORT`               | Connection port                       | No       | Based on protocol |
-| `S3_USE_SSL`            | Enable SSL/TLS encryption             | Yes      | `true`            |
-| `S3_ACCESS_KEY`         | Access key for authentication         | Yes      | -                 |
-| `S3_SECRET_KEY`         | Secret key for authentication         | Yes      | -                 |
-| `S3_REGION`             | Storage region                        | Yes      | -                 |
-| `S3_BUCKET_NAME`        | Bucket/container name                 | Yes      | -                 |
-| `S3_FORCE_PATH_STYLE`   | Use path-style URLs                   | No       | `false`           |
-| `S3_REJECT_UNAUTHORIZED`| Enable strict SSL certificate validation | No    | `true`            |
+| Variable                 | Description                              | Required | Default           |
+| ------------------------ | ---------------------------------------- | -------- | ----------------- |
+| `S3_ENDPOINT`            | S3 provider endpoint URL                 | Yes      | -                 |
+| `S3_PORT`                | Connection port                          | No       | Based on protocol |
+| `S3_USE_SSL`             | Enable SSL/TLS encryption                | Yes      | `true`            |
+| `S3_ACCESS_KEY`          | Access key for authentication            | Yes      | -                 |
+| `S3_SECRET_KEY`          | Secret key for authentication            | Yes      | -                 |
+| `S3_REGION`              | Storage region                           | Yes      | -                 |
+| `S3_BUCKET_NAME`         | Bucket/container name                    | Yes      | -                 |
+| `S3_FORCE_PATH_STYLE`    | Use path-style URLs                      | No       | `false`           |
+| `S3_REJECT_UNAUTHORIZED` | Enable strict SSL certificate validation | No       | `true`            |
 
 ## Provider configurations
 
@@ -52,6 +62,7 @@ S3_SECRET_KEY=your-secret-access-key
 S3_REGION=us-east-1
 S3_BUCKET_NAME=your-bucket-name
 S3_FORCE_PATH_STYLE=false
+# PRESIGNED_URL_EXPIRATION=3600  # Optional: 1 hour (default)
 ```
 
 **Getting credentials:**
@@ -153,6 +164,7 @@ S3_SECRET_KEY=your-application-key
 S3_REGION=us-west-002
 S3_BUCKET_NAME=your-bucket-name
 S3_FORCE_PATH_STYLE=false
+# PRESIGNED_URL_EXPIRATION=7200  # Optional: 2 hours for large files
 ```
 
 **Cost advantage:**
@@ -202,6 +214,93 @@ S3_FORCE_PATH_STYLE=false
 - Enable S3-compatible API in Azure
 - Use container name as bucket name
 - Configure appropriate access policies
+
+## Presigned URL configuration
+
+Palmr. uses presigned URLs to provide secure, temporary access to files stored in **both S3-compatible storage and filesystem storage**. These URLs have a configurable expiration time to balance security and usability.
+
+> **Note:** This configuration applies to **all storage types** (S3, filesystem, etc.), not just S3-compatible storage.
+
+### Understanding presigned URLs
+
+Presigned URLs are temporary URLs that allow direct access to files without exposing storage credentials or requiring authentication. They automatically expire after a specified time period, enhancing security by limiting access duration.
+
+**How it works:**
+
+- **S3 Storage:** URLs are signed by AWS/S3-compatible provider credentials
+- **Filesystem Storage:** URLs use temporary tokens that are validated by Palmr server
+
+**Default behavior:**
+
+- Upload URLs: 1 hour (3600 seconds)
+- Download URLs: 1 hour (3600 seconds)
+
+### Configuring expiration time
+
+You can customize the expiration time using the `PRESIGNED_URL_EXPIRATION` environment variable:
+
+```bash
+# Set URLs to expire after 2 hours (7200 seconds)
+PRESIGNED_URL_EXPIRATION=7200
+
+# Set URLs to expire after 30 minutes (1800 seconds)
+PRESIGNED_URL_EXPIRATION=1800
+
+# Set URLs to expire after 6 hours (21600 seconds)
+PRESIGNED_URL_EXPIRATION=21600
+```
+
+### Choosing the right expiration time
+
+**Shorter expiration (15-30 minutes):**
+
+- [+] Higher security
+- [+] Reduced risk of unauthorized access
+- [-] May interrupt long uploads/downloads
+- [-] Users may need to refresh links more often
+
+**Longer expiration (2-6 hours):**
+
+- [+] Better user experience for large files
+- [+] Fewer interruptions during transfers
+- [-] Longer exposure window if URLs are compromised
+- [-] Potential for increased storage costs if users leave downloads incomplete
+
+**Recommended settings:**
+
+- **High security environments:** 1800 seconds (30 minutes)
+- **Standard usage:** 3600 seconds (1 hour) - default
+- **Large file transfers:** 7200-21600 seconds (2-6 hours)
+
+### Example configurations
+
+**For Backblaze B2 with extended expiration:**
+
+```bash
+ENABLE_S3=true
+S3_ENDPOINT=s3.us-west-002.backblazeb2.com
+S3_USE_SSL=true
+S3_ACCESS_KEY=your-key-id
+S3_SECRET_KEY=your-application-key
+S3_REGION=us-west-002
+S3_BUCKET_NAME=your-bucket-name
+S3_FORCE_PATH_STYLE=false
+PRESIGNED_URL_EXPIRATION=7200  # 2 hours for large file transfers
+```
+
+**For high-security environments:**
+
+```bash
+ENABLE_S3=true
+S3_ENDPOINT=s3.amazonaws.com
+S3_USE_SSL=true
+S3_ACCESS_KEY=your-access-key-id
+S3_SECRET_KEY=your-secret-access-key
+S3_REGION=us-east-1
+S3_BUCKET_NAME=your-bucket-name
+S3_FORCE_PATH_STYLE=false
+PRESIGNED_URL_EXPIRATION=1800  # 30 minutes for enhanced security
+```
 
 ## Configuration best practices
 

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -15,3 +15,4 @@ DATABASE_URL="file:./palmr.db"
 # S3_BUCKET_NAME=
 # S3_FORCE_PATH_STYLE=
 # S3_REJECT_UNAUTHORIZED=true # Set to false to disable strict SSL certificate validation for self-signed certificates (optional, defaults to true)
+# PRESIGNED_URL_EXPIRATION=3600 # Duration in seconds for presigned URL expiration (optional, defaults to 3600 seconds / 1 hour)

--- a/apps/server/src/env.ts
+++ b/apps/server/src/env.ts
@@ -13,6 +13,7 @@ const envSchema = z.object({
   S3_BUCKET_NAME: z.string().optional(),
   S3_FORCE_PATH_STYLE: z.union([z.literal("true"), z.literal("false")]).default("false"),
   S3_REJECT_UNAUTHORIZED: z.union([z.literal("true"), z.literal("false")]).default("true"),
+  PRESIGNED_URL_EXPIRATION: z.string().optional().default("3600"),
   SECURE_SITE: z.union([z.literal("true"), z.literal("false")]).default("false"),
   DATABASE_URL: z.string().optional().default("file:/app/server/prisma/palmr.db"),
 });

--- a/apps/server/src/modules/file/controller.ts
+++ b/apps/server/src/modules/file/controller.ts
@@ -28,7 +28,7 @@ export class FileController {
       }
 
       const objectName = `${userId}/${Date.now()}-${filename}.${extension}`;
-      const expires = 3600;
+      const expires = parseInt(env.PRESIGNED_URL_EXPIRATION);
 
       const url = await this.fileService.getPresignedPutUrl(objectName, expires);
       return reply.send({ url, objectName });
@@ -172,7 +172,7 @@ export class FileController {
         return reply.status(404).send({ error: "File not found." });
       }
       const fileName = fileRecord.name;
-      const expires = 3600;
+      const expires = parseInt(env.PRESIGNED_URL_EXPIRATION);
       const url = await this.fileService.getPresignedGetUrl(objectName, expires, fileName);
       return reply.send({ url, expiresIn: expires });
     } catch (error) {

--- a/apps/server/src/modules/reverse-share/service.ts
+++ b/apps/server/src/modules/reverse-share/service.ts
@@ -227,7 +227,7 @@ export class ReverseShareService {
       }
     }
 
-    const expires = 3600; // 1 hour
+    const expires = parseInt(env.PRESIGNED_URL_EXPIRATION);
     const url = await this.fileService.getPresignedPutUrl(objectName, expires);
 
     return { url, expiresIn: expires };
@@ -257,7 +257,7 @@ export class ReverseShareService {
       }
     }
 
-    const expires = 3600; // 1 hour
+    const expires = parseInt(env.PRESIGNED_URL_EXPIRATION);
     const url = await this.fileService.getPresignedPutUrl(objectName, expires);
 
     return { url, expiresIn: expires };
@@ -378,7 +378,7 @@ export class ReverseShareService {
     }
 
     const fileName = file.name;
-    const expires = 3600; // 1 hour
+    const expires = parseInt(env.PRESIGNED_URL_EXPIRATION);
     const url = await this.fileService.getPresignedGetUrl(file.objectName, expires, fileName);
     return { url, expiresIn: expires };
   }

--- a/docker-compose-bind-mount-example.yaml
+++ b/docker-compose-bind-mount-example.yaml
@@ -11,6 +11,7 @@ services:
       # - PALMR_UID=1000 # UID for the container processes (OPTIONAL - default is 1000) | See our UID/GID Documentation for more information
       # - PALMR_GID=1000 # GID for the container processes (OPTIONAL - default is 1000) | See our UID/GID Documentation for more information
       # - DEFAULT_LANGUAGE=en-US # Default language for the application (optional, defaults to en-US) | See the docs for see all supported languages
+      # - PRESIGNED_URL_EXPIRATION=3600 # Duration in seconds for presigned URL expiration (OPTIONAL - default is 3600 seconds / 1 hour)
       # - SECURE_SITE=true # Set to true if you are using a reverse proxy (OPTIONAL - default is false)
     ports:
       - "5487:5487" # Web port

--- a/docker-compose-minio.yaml
+++ b/docker-compose-minio.yaml
@@ -16,6 +16,7 @@ services:
       # - PALMR_UID=1000 # UID for the container processes (OPTIONAL - default is 1000) | See our UID/GID Documentation for more information
       # - PALMR_GID=1000 # GID for the container processes (OPTIONAL - default is 1000) | See our UID/GID Documentation for more information
       # - DEFAULT_LANGUAGE=en-US # Default language for the application (optional, defaults to en-US) | See the docs for see all supported languages
+      # - PRESIGNED_URL_EXPIRATION=3600 # Duration in seconds for presigned URL expiration (OPTIONAL - default is 3600 seconds / 1 hour)
       # - SECURE_SITE=true # Set to true if you are using a reverse proxy (OPTIONAL - default is false)
     ports:
       - "5487:5487" # Web port

--- a/docker-compose-s3.yaml
+++ b/docker-compose-s3.yaml
@@ -16,6 +16,7 @@ services:
       # - PALMR_UID=1000 # UID for the container processes (OPTIONAL - default is 1000) | See our UID/GID Documentation for more information
       # - PALMR_GID=1000 # GID for the container processes (OPTIONAL - default is 1000) | See our UID/GID Documentation for more information
       # - DEFAULT_LANGUAGE=en-US # Default language for the application (optional, defaults to en-US) | See the docs for see all supported languages
+      # - PRESIGNED_URL_EXPIRATION=3600 # Duration in seconds for presigned URL expiration (OPTIONAL - default is 3600 seconds / 1 hour)
       # - SECURE_SITE=true # Set to true if you are using a reverse proxy (OPTIONAL - default is false)
     ports:
       - "5487:5487" # Web port

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,7 @@ services:
       # - PALMR_UID=1000 # UID for the container processes (OPTIONAL - default is 1000) | See our UID/GID Documentation for more information
       # - PALMR_GID=1000 # GID for the container processes (OPTIONAL - default is 1000) | See our UID/GID Documentation for more information
       # - DEFAULT_LANGUAGE=en-US # Default language for the application (optional, defaults to en-US) | See the docs to see all supported languages
+      # - PRESIGNED_URL_EXPIRATION=3600 # Duration in seconds for presigned URL expiration (OPTIONAL - default is 3600 seconds / 1 hour)
       # - SECURE_SITE=true # Set to true if you are using a reverse proxy (OPTIONAL - default is false)
     ports:
       - "5487:5487" # Web port


### PR DESCRIPTION
- Introduced the PRESIGNED_URL_EXPIRATION environment variable across multiple configuration files to allow users to customize the expiration time for presigned URLs.
- Updated documentation to include details on the new variable, its default value, and guidance on choosing appropriate expiration times based on security and usability needs.
- Refactored relevant code to utilize the new configuration option for generating presigned URLs in the file and reverse share services.
