### PR TITLE
feat: make upload chunk size configurable

### DIFF
--- a/apps/docs/content/docs/3.2-beta/manual-installation.mdx
+++ b/apps/docs/content/docs/3.2-beta/manual-installation.mdx
@@ -165,6 +165,27 @@ cp .env.example .env
 
 This creates a `.env` file with the necessary configurations for the frontend.
 
+##### Upload Configuration
+
+Palmr. supports configurable chunked uploading for large files. You can customize the chunk size by setting the following environment variable in your `.env` file:
+
+```bash
+NEXT_PUBLIC_UPLOAD_CHUNK_SIZE_MB=100
+```
+
+**How it works:**
+
+- If `NEXT_PUBLIC_UPLOAD_CHUNK_SIZE_MB` is set, Palmr. will use this value (in megabytes) as the chunk size for all file uploads that exceed this threshold.
+- If not set or left empty, Palmr. automatically calculates optimal chunk sizes based on file size:
+  - Files ≤ 100MB: uploaded without chunking
+  - Files > 100MB and ≤ 1GB: 75MB chunks
+  - Files > 1GB: 150MB chunks
+
+**When to configure:**
+
+- **Default (not set):** Recommended for most use cases. Palmr. will intelligently determine the best chunk size.
+- **Custom value:** Set this if you have specific network conditions or want to optimize for your infrastructure (e.g., slower connections may benefit from smaller chunks like 50MB, while fast networks can handle larger chunks like 200MB, or the upload size per payload may be limited by a proxy like Cloudflare)
+
 #### Install dependencies
 
 Install all the frontend dependencies:

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,2 +1,5 @@
 API_BASE_URL=http:localhost:3333
 NEXT_PUBLIC_DEFAULT_LANGUAGE=en-US
+
+# Configuration options
+NEXT_PUBLIC_UPLOAD_CHUNK_SIZE_MB=

--- a/apps/web/src/utils/chunked-upload.ts
+++ b/apps/web/src/utils/chunked-upload.ts
@@ -260,7 +260,7 @@ export class ChunkedUploader {
   static calculateOptimalChunkSize(fileSize: number): number {
     const configuredChunkSize = this.getConfiguredChunkSize();
     const chunkSize = configuredChunkSize || this.defaultChunkSizeInBytes;
-    
+
     if (fileSize <= chunkSize) {
       throw new Error(
         `calculateOptimalChunkSize should not be called for files <= ${chunkSize}. File size: ${(fileSize / (1024 * 1024)).toFixed(2)}MB`

--- a/apps/web/src/utils/chunked-upload.ts
+++ b/apps/web/src/utils/chunked-upload.ts
@@ -18,6 +18,8 @@ export interface ChunkedUploadResult {
 }
 
 export class ChunkedUploader {
+  private static defaultChunkSizeInBytes = 100 * 1024 * 1024; // 100MB
+
   /**
    * Upload a file in chunks with streaming
    */
@@ -246,7 +248,7 @@ export class ChunkedUploader {
       return false;
     }
 
-    const threshold = 100 * 1024 * 1024; // 100MB
+    const threshold = this.getConfiguredChunkSize() || this.defaultChunkSizeInBytes;
     const shouldUse = fileSize > threshold;
 
     return shouldUse;
@@ -256,10 +258,17 @@ export class ChunkedUploader {
    * Calculate optimal chunk size based on file size
    */
   static calculateOptimalChunkSize(fileSize: number): number {
-    if (fileSize <= 100 * 1024 * 1024) {
+    const configuredChunkSize = this.getConfiguredChunkSize();
+    const chunkSize = configuredChunkSize || this.defaultChunkSizeInBytes;
+    
+    if (fileSize <= chunkSize) {
       throw new Error(
-        `calculateOptimalChunkSize should not be called for files <= 100MB. File size: ${(fileSize / (1024 * 1024)).toFixed(2)}MB`
+        `calculateOptimalChunkSize should not be called for files <= ${chunkSize}. File size: ${(fileSize / (1024 * 1024)).toFixed(2)}MB`
       );
+    }
+
+    if (configuredChunkSize) {
+      return configuredChunkSize;
     }
 
     // For files > 1GB, use 150MB chunks
@@ -274,5 +283,25 @@ export class ChunkedUploader {
 
     // For files > 100MB, use 75MB chunks (minimum for chunked upload)
     return 75 * 1024 * 1024;
+  }
+
+  private static getConfiguredChunkSize(): number | null {
+    const configuredChunkSizeMb = process.env.NEXT_PUBLIC_UPLOAD_CHUNK_SIZE_MB;
+
+    if (!configuredChunkSizeMb) {
+      return null;
+    }
+
+    const parsedValue = Number(configuredChunkSizeMb);
+
+    if (Number.isNaN(parsedValue) || parsedValue <= 0) {
+      console.warn(
+        `Invalid NEXT_PUBLIC_UPLOAD_CHUNK_SIZE_MB value: ${configuredChunkSizeMb}. Falling back to optimal chunk size.`
+      );
+
+      return null;
+    }
+
+    return Math.floor(parsedValue * 1024 * 1024);
   }
 }


### PR DESCRIPTION

## 📝 Description

Adds a configurable upload chunk size

- Chunk logic 
`apps/web/src/utils/chunked-upload.ts` now respects NEXT_PUBLIC_UPLOAD_CHUNK_SIZE_MB and falls back to optimal sizing when unset/invalid.
- Env template documents the new variable in `apps/web/.env.example`
- Docs add “Upload Configuration” guidance in `apps/docs/content/docs/3.2-beta/manual-installation.mdx`

## 🔗 Related Issue(s)

None

## 💡 Motivation and Context

Although the optimal chunk size calculation is great, it causes issues with some proxies with limited upload limit, like Cloudflare (100mb on free plan). Using chunk uploads of less than 100mb in this case would fix the issue.

## 🤖 Use of Artificial Intelligence (AI)

The use of AI tools is absolutely welcome and not an issue. For transparency and continuous improvement, please answer the following:

- Did you use any AI tools (such as GitHub Copilot, ChatGPT, etc.) to help develop this PR?
    - [ ] No, this PR was developed without the assistance of AI tools.
    - [x] Yes, AI tools assisted in the development of this PR (please specify which ones and how they were used):
        - Tool(s) used: Windsurf, GPT-5-Codex, Claude Sonnet 4.5
        - Brief description of how AI contributed: Understand the code structure, write minimal changes (tweaked and approved by human engineer), write documentation
- Was this PR generated entirely by an AI tool (i.e., with minimal human intervention)?  
    - [ ] No  
    - [x] Yes (please provide details): Only the summary was generated

## 🧪 How Has This Been Tested?

# Manual User Action Tests

- **[Env: set below-threshold file]**  
  1. In `apps/web/.env`, set `NEXT_PUBLIC_UPLOAD_CHUNK_SIZE_MB=50`.  
  2. Upload a file smaller than 50 MB. Expect a single file to be uploaded (not chunked)

- **[Env: set above-threshold file]**  
  1. With the same env value, upload a file larger than 50 MB.  
  2. Confirm multiple chunk requests appear, using the configured ~50 MB chunk size

- **[Env: unset fallback]**  
  1. Remove or comment `NEXT_PUBLIC_UPLOAD_CHUNK_SIZE_MB` and restart `pnpm dev`.  
  2. Upload a file ≤100 MB; expect a single upload (no chunking).  
  3. Upload a file between 100 MB and 1 GB; expect 75 MB chunks.  
  4. Upload a file >1 GB; expect 150 MB chunks. These defaults validate the automatic sizing logic.

- **[Optional invalid value check]**  
  1. Set an invalid value (e.g., `NEXT_PUBLIC_UPLOAD_CHUNK_SIZE_MB=abc`), restart, reload.  
  2. Observe the console warning issued and repeat the >100 MB upload to verify fallback to optimal sizing.

## 📸 Screenshots (if appropriate)

N/A

## 🔄 Types of Changes

Check the relevant option(s) below:

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📚 Documentation update

## ✅ Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have rebased and/or merged on top of the latest `next` branch

---

🙏 Thank you for your contribution!