### PR TITLE
Set explicit config location for mc commands to fix UNRAID error

### DIFF
--- a/infra/minio-setup.sh
+++ b/infra/minio-setup.sh
@@ -58,12 +58,14 @@ if [ "$(id -u)" = "0" ]; then
     chown -R $TARGET_UID:$TARGET_GID /home/palmr 2>/dev/null || true
 fi
 
-# Run mc commands as target user
+# Run mc commands as target user with explicit config location
 run_as_target() {
     if [ "$(id -u)" = "0" ]; then
-        su-exec $TARGET_UID:$TARGET_GID "$@"
+        su-exec $TARGET_UID:$TARGET_GID \
+            env HOME="/home/palmr" MC_CONFIG_DIR="/home/palmr/.mc" \
+            "$@"
     else
-        "$@"
+        HOME="/home/palmr" MC_CONFIG_DIR="/home/palmr/.mc" "$@"
     fi
 }
 


### PR DESCRIPTION
## 📝 Description
Fixes local file uploads on UNRAID, the docker container can't make the folder as the home path is not set correctly and this fixes it.

## 🔗 Related Issue(s)

Closes https://github.com/kyantech/Palmr/issues/401

## 💡 Motivation and Context

Plamr uploading to internal storage is broken for local storage.

## 🤖 Use of Artificial Intelligence (AI)

The use of AI tools is absolutely welcome and not an issue. For transparency and continuous improvement, please answer the following:

- Did you use any AI tools (such as GitHub Copilot, ChatGPT, etc.) to help develop this PR?
    - [ ] No, this PR was developed without the assistance of AI tools.
    - [X] Yes, AI tools assisted in the development of this PR (please specify which ones and how they were used):
        - Tool(s) used: ChatGPT
        - Brief description of how AI contributed: Explaining the problem. and offering some examples of fixes.
- Was this PR generated entirely by an AI tool (i.e., with minimal human intervention)?  
    - [X] No  
    - [ ] Yes (please provide details):

## 🧪 How Has This Been Tested?

1. Connected to the running docker container
2. Made the change
3. Rebooted the container
4. Problem is fixed

## 📸 Screenshots (if appropriate)

Snippet of log:
[STORAGE-SYSTEM-SETUP] Configuring storage client...
mc: <ERROR> Unable to save new mc config. mkdir /.mc: permission denied.
[STORAGE-SYSTEM-SETUP] ✗ Failed to configure storage client
[STORAGE-SYSTEM-SETUP] Debug: UID/GID=99:100, User=root

## 🔄 Types of Changes

Check the relevant option(s) below:

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update

## ✅ Checklist

- [X] My code follows the code style of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [X] I have rebased and/or merged on top of the latest `next` branch
